### PR TITLE
Preventing Return Register Clobbering from Multi-Operand Expressions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,20 @@
 # Changelog
 
+[0.7.3]
+
+- Fixed an issue where scripts could read the wrong value when multiple device/system
+  reads were used inside the same expression
+  - This mainly affected more advanced one-liner calculations, especially when combining
+    batch reads and math helper calls in a single statement
+  - In some cases, the second read could overwrite the first one before the calculation
+    finished, leading to incorrect automation behavior
+- Added broader safeguards so multi-part expressions now preserve each intermediate
+  value correctly
+- Added regression tests covering affected syscall combinations to help prevent this
+  issue from returning
+- No script changes are required for most users; existing scripts should now produce
+  more reliable results
+
 [0.7.2]
 
 - Fixed a stack overflow issue that could occur in scripts using nested function

--- a/ModData/About/About.xml
+++ b/ModData/About/About.xml
@@ -2,7 +2,7 @@
 <ModMetadata xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Name>Slang</Name>
   <Author>JoeDiertay</Author>
-  <Version>0.7.2</Version>
+  <Version>0.7.3</Version>
   <Description>
 [h1]Slang: High-Level Programming for Stationeers[/h1]
 

--- a/csharp_mod/Plugin.cs
+++ b/csharp_mod/Plugin.cs
@@ -39,7 +39,7 @@ namespace Slang
     {
         public const string PluginGuid = "com.biddydev.slang";
         public const string PluginName = "Slang";
-        public const string PluginVersion = "0.7.2";
+        public const string PluginVersion = "0.7.3";
 
         private static Harmony? _harmony;
 

--- a/csharp_mod/stationeersSlang.csproj
+++ b/csharp_mod/stationeersSlang.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <AssemblyName>StationeersSlang</AssemblyName>
     <Description>Slang Compiler Bridge</Description>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/rust_compiler/Cargo.lock
+++ b/rust_compiler/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slang"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/rust_compiler/Cargo.toml
+++ b/rust_compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slang"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 
 [workspace]

--- a/rust_compiler/libs/compiler/src/test/binary_expression.rs
+++ b/rust_compiler/libs/compiler/src/test/binary_expression.rs
@@ -212,6 +212,47 @@ fn test_ternary_expression_assignment() -> Result<()> {
 }
 
 #[test]
+fn test_ternary_expression_from_syscalls() -> Result<()> {
+
+    let compiled = compile! {
+        check
+        r#"
+        device dev0 = "d0";
+        device dev1 = "d1";
+        device dev2 = "d2";
+
+        let i = l(dev0, "Setting") ? l(dev1, "Setting") : l(dev2, "Setting");
+        "#
+    };
+
+    assert!(
+        compiled.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        compiled.errors
+    );
+
+    assert_eq!(
+        compiled.output,
+        indoc! {
+            "
+            j main
+            main:
+            l r15 d0 Setting
+            move r1 r15
+            l r15 d1 Setting
+            move r2 r15
+            l r15 d2 Setting
+            select r3 r1 r2 r15
+            move r8 r3
+            "
+        }
+    );
+
+    Ok(())
+}
+
+
+#[test]
 fn test_negative_literals() -> Result<()> {
     let result = compile!(
     check

--- a/rust_compiler/libs/compiler/src/test/binary_expression.rs
+++ b/rust_compiler/libs/compiler/src/test/binary_expression.rs
@@ -213,6 +213,8 @@ fn test_ternary_expression_assignment() -> Result<()> {
 
 #[test]
 fn test_ternary_expression_from_syscalls() -> Result<()> {
+    // (atakehar) "from_syscalls" checks that expresssions of multiple sub-expressions each using
+    // the return register (r15) do not clobber eachother.
 
     let compiled = compile! {
         check

--- a/rust_compiler/libs/compiler/src/test/device_access.rs
+++ b/rust_compiler/libs/compiler/src/test/device_access.rs
@@ -333,6 +333,39 @@ fn device_index_write() -> anyhow::Result<()> {
 }
 
 #[test]
+fn device_index_write_with_syscall() -> anyhow::Result<()> {
+    let compiled = compile! {
+        check "
+            device printer = \"d0\";
+            device mem = \"d1\";
+            printer[l(mem, \"Setting\")] = l(mem, \"Mode\");
+        "
+    };
+
+    assert!(
+        compiled.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        compiled.errors
+    );
+
+    assert_eq!(
+        compiled.output,
+        indoc! {
+            "
+            j main
+            main:
+            l r15 d1 Setting
+            move r1 r15
+            l r15 d1 Mode
+            put d0 r1 r15
+            "
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
 fn device_index_db_not_allowed() -> anyhow::Result<()> {
     let compiled = compile! {
         check "

--- a/rust_compiler/libs/compiler/src/test/edge_cases.rs
+++ b/rust_compiler/libs/compiler/src/test/edge_cases.rs
@@ -711,6 +711,8 @@ fn tuple_from_simple_function() -> anyhow::Result<()> {
 
 #[test]
 fn tuple_from_syscalls_from_simple_function() -> anyhow::Result<()> {
+    // (atakehar) "from_syscalls" checks that expresssions of multiple sub-expressions each using
+    // the return register (r15) do not clobber eachother.
     let compiled = compile! {
         check "
             device dev0 = \"d0\";

--- a/rust_compiler/libs/compiler/src/test/edge_cases.rs
+++ b/rust_compiler/libs/compiler/src/test/edge_cases.rs
@@ -710,6 +710,57 @@ fn tuple_from_simple_function() -> anyhow::Result<()> {
 }
 
 #[test]
+fn tuple_from_syscalls_from_simple_function() -> anyhow::Result<()> {
+    let compiled = compile! {
+        check "
+            device dev0 = \"d0\";
+            device dev1 = \"d1\";
+
+            fn get_pair() {
+                return (l(dev0, \"Setting\"), l(dev1, \"Setting\"));
+            }
+
+            let (a, b) = get_pair();
+        "
+    };
+
+    assert!(
+        compiled.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        compiled.errors
+    );
+
+    assert_eq!(
+        compiled.output,
+        indoc! {"
+            j main
+            get_pair:
+            push sp
+            push ra
+            l r15 d0 Setting
+            push r15
+            l r15 d1 Setting
+            push r15
+            sub r0 sp 4
+            get r0 db r0
+            move r15 r0
+            j __internal_L1
+            __internal_L1:
+            sub r0 sp 3
+            get ra db r0
+            j ra
+            main:
+            jal get_pair
+            pop r9
+            pop r8
+            move sp r15
+        "}
+    );
+
+    Ok(())
+}
+
+#[test]
 fn tuple_from_expression_not_function() -> anyhow::Result<()> {
     let compiled = compile! {
         check "

--- a/rust_compiler/libs/compiler/src/test/logic_expression.rs
+++ b/rust_compiler/libs/compiler/src/test/logic_expression.rs
@@ -47,6 +47,40 @@ fn test_comparison_expressions() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_comparison_expression_with_syscall() -> anyhow::Result<()> {
+    let result = compile! {
+        check
+        "
+        device dev = \"d0\";
+        let isGreater = l(dev, \"PressureInput\") > l(dev, \"PressureOutput\");
+        "
+    };
+
+    assert!(
+        result.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        result.errors
+    );
+
+    assert_eq!(
+        result.output,
+        indoc! {
+            "
+            j main
+            main:
+            l r15 d0 PressureInput
+            move r1 r15
+            l r15 d0 PressureOutput
+            sgt r2 r1 r15
+            move r8 r2
+            "
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_logical_and_or_not() -> anyhow::Result<()> {
     let result = compile! {
         check

--- a/rust_compiler/libs/compiler/src/test/math_syscall.rs
+++ b/rust_compiler/libs/compiler/src/test/math_syscall.rs
@@ -372,6 +372,8 @@ fn test_max_from_game() -> Result<()> {
 
 #[test]
 fn test_max_from_syscalls() -> anyhow::Result<()> {
+    // (atakehar) "from_syscalls" checks that expresssions of multiple sub-expressions each using
+    // the return register (r15) do not clobber eachother.
     let compiled = compile! {
         check
         r#"
@@ -437,6 +439,8 @@ fn test_min() -> Result<()> {
 
 #[test]
 fn test_min_from_syscalls() -> anyhow::Result<()> {
+    // (atakehar) "from_syscalls" checks that expresssions of multiple sub-expressions each using
+    // the return register (r15) do not clobber eachother.
     let compiled = compile! {
         check
         r#"

--- a/rust_compiler/libs/compiler/src/test/math_syscall.rs
+++ b/rust_compiler/libs/compiler/src/test/math_syscall.rs
@@ -123,6 +123,42 @@ fn test_atan2() -> Result<()> {
 }
 
 #[test]
+fn test_atan2_from_syscall() -> Result<()> {
+    let compiled = compile! {
+        check
+        "
+        device arg0 = \"d0\";
+        device arg1 = \"d1\";
+
+        let i = atan2(l(arg0, \"Setting\"), l(arg1, \"Setting\"));
+        "
+    };
+
+    assert!(
+        compiled.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        compiled.errors
+    );
+
+    assert_eq!(
+        compiled.output,
+        indoc! {
+            "
+            j main
+            main:
+            l r15 d0 Setting
+            move r1 r15
+            l r15 d1 Setting
+            atan2 r15 r1 r15
+            move r8 r15
+            "
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_abs() -> Result<()> {
     let compiled = compile! {
         check
@@ -335,6 +371,41 @@ fn test_max_from_game() -> Result<()> {
 }
 
 #[test]
+fn test_max_from_syscalls() -> anyhow::Result<()> {
+    let compiled = compile! {
+        check
+        r#"
+        device filtration = "d0";
+
+        let largestQuantity = max(ls(filtration, 0, "Quantity"), ls(filtration, 1, "Quantity"));
+        "#
+    };
+
+    assert!(
+        compiled.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        compiled.errors
+    );
+
+    assert_eq!(
+        compiled.output,
+        indoc! {
+            "
+            j main
+            main:
+            ls r15 d0 0 Quantity
+            move r1 r15
+            ls r15 d0 1 Quantity
+            max r15 r1 r15
+            move r8 r15
+            "
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_min() -> Result<()> {
     let compiled = compile! {
         check
@@ -356,6 +427,41 @@ fn test_min() -> Result<()> {
             j main
             main:
             min r15 123 456
+            move r8 r15
+            "
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_min_from_syscalls() -> anyhow::Result<()> {
+    let compiled = compile! {
+        check
+        r#"
+        device filtration = "d0";
+
+        let smallestQuantity = min(ls(filtration, 0, "Quantity"), ls(filtration, 1, "Quantity"));
+        "#
+    };
+
+    assert!(
+        compiled.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        compiled.errors
+    );
+
+    assert_eq!(
+        compiled.output,
+        indoc! {
+            "
+            j main
+            main:
+            ls r15 d0 0 Quantity
+            move r1 r15
+            ls r15 d0 1 Quantity
+            min r15 r1 r15
             move r8 r15
             "
         }

--- a/rust_compiler/libs/compiler/src/test/syscall.rs
+++ b/rust_compiler/libs/compiler/src/test/syscall.rs
@@ -496,6 +496,8 @@ fn test_load_batched_named_slot() -> anyhow::Result<()> {
 
 #[test]
 fn test_load_batched_slot_from_syscalls() -> anyhow::Result<()> {
+    // (atakehar) "from_syscalls" checks that expresssions of multiple sub-expressions each using
+    // the return register (r15) do not clobber eachother.
     let compiled = compile! {
         check
         r#"
@@ -531,6 +533,8 @@ fn test_load_batched_slot_from_syscalls() -> anyhow::Result<()> {
 
 #[test]
 fn test_load_batched_named_slot_from_syscalls() -> anyhow::Result<()> {
+    // (atakehar) "from_syscalls" checks that expresssions of multiple sub-expressions each using
+    // the return register (r15) do not clobber eachother.
     let compiled = compile! {
         check
         r#"

--- a/rust_compiler/libs/compiler/src/test/syscall.rs
+++ b/rust_compiler/libs/compiler/src/test/syscall.rs
@@ -296,6 +296,42 @@ fn test_set_slot() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_set_slot_from_syscall() -> anyhow::Result<()> {
+    let compiled = compile! {
+        check
+        r#"
+        device airCon = "d0";
+        device indexMem = "d1";
+        device valueMem = "d2";
+
+        ss(airCon, l(indexMem, "Setting"), "Occupied", l(valueMem, "Setting"));
+        "#
+    };
+
+    assert!(
+        compiled.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        compiled.errors
+    );
+
+    assert_eq!(
+        compiled.output,
+        indoc! {
+            "
+            j main
+            main:
+            l r15 d1 Setting
+            move r1 r15
+            l r15 d2 Setting
+            ss d0 r1 Occupied r15
+            "
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_load_reagent() -> anyhow::Result<()> {
     let compiled = compile! {
         check
@@ -451,6 +487,79 @@ fn test_load_batched_named_slot() -> anyhow::Result<()> {
             move r9 67890
             lbns r15 r8 r9 0 Occupied Average
             move r10 r15
+            "
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_load_batched_slot_from_syscalls() -> anyhow::Result<()> {
+    let compiled = compile! {
+        check
+        r#"
+        device hashMem = "d0";
+        device indexMem = "d1";
+        let slotOccupied = lbs(l(hashMem, "Setting"), l(indexMem, "Setting"), "Occupied", "Average");
+        "#
+    };
+
+    assert!(
+        compiled.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        compiled.errors
+    );
+
+    assert_eq!(
+        compiled.output,
+        indoc! {
+            "
+            j main
+            main:
+            l r15 d0 Setting
+            move r1 r15
+            l r15 d1 Setting
+            lbs r15 r1 r15 Occupied Average
+            move r8 r15
+            "
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_load_batched_named_slot_from_syscalls() -> anyhow::Result<()> {
+    let compiled = compile! {
+        check
+        r#"
+        device hashMem = "d0";
+        device nameMem = "d1";
+        device indexMem = "d2";
+        let slotOccupied = lbns(l(hashMem, "Setting"), l(nameMem, "Setting"), l(indexMem, "Setting"), "Occupied", "Average");
+        "#
+    };
+
+    assert!(
+        compiled.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        compiled.errors
+    );
+
+    assert_eq!(
+        compiled.output,
+        indoc! {
+            "
+            j main
+            main:
+            l r15 d0 Setting
+            move r1 r15
+            l r15 d1 Setting
+            move r2 r15
+            l r15 d2 Setting
+            lbns r15 r1 r2 r15 Occupied Average
+            move r8 r15
             "
         }
     );

--- a/rust_compiler/libs/compiler/src/test/syscall.rs
+++ b/rust_compiler/libs/compiler/src/test/syscall.rs
@@ -495,6 +495,41 @@ fn test_load_batched_named_slot() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_load_batched_named_from_syscalls() -> anyhow::Result<()> {
+    let compiled = compile! {
+        check
+        r#"
+        device hashMem = "d0";
+        device nameMem = "d1";
+        let occupiedAverage = lbn(l(hashMem, "Setting"), l(nameMem, "Setting"), "Occupied", "Average");
+        "#
+    };
+
+    assert!(
+        compiled.errors.is_empty(),
+        "Expected no errors, got: {:?}",
+        compiled.errors
+    );
+
+    assert_eq!(
+        compiled.output,
+        indoc! {
+            "
+            j main
+            main:
+            l r15 d0 Setting
+            move r1 r15
+            l r15 d1 Setting
+            lbn r15 r1 r15 Occupied Average
+            move r8 r15
+            "
+        }
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_load_batched_slot_from_syscalls() -> anyhow::Result<()> {
     // (atakehar) "from_syscalls" checks that expresssions of multiple sub-expressions each using
     // the return register (r15) do not clobber eachother.

--- a/rust_compiler/libs/compiler/src/test/tuple_literals.rs
+++ b/rust_compiler/libs/compiler/src/test/tuple_literals.rs
@@ -64,6 +64,8 @@ mod test {
 
     #[test]
     fn test_tuple_literal_declaration_from_syscalls() -> anyhow::Result<()> {
+        // (atakehar) "from_syscalls" checks that expresssions of multiple sub-expressions each using
+        // the return register (r15) do not clobber eachother.
         let compiled = compile!(
             check
             r#"

--- a/rust_compiler/libs/compiler/src/test/tuple_literals.rs
+++ b/rust_compiler/libs/compiler/src/test/tuple_literals.rs
@@ -63,6 +63,40 @@ mod test {
     }
 
     #[test]
+    fn test_tuple_literal_declaration_from_syscalls() -> anyhow::Result<()> {
+        let compiled = compile!(
+            check
+            r#"
+            device dev0 = "d0";
+            device dev1 = "d1";
+            let (x, y) = (l(dev0, "Setting"), l(dev1, "Setting"));
+            "#
+        );
+
+        assert!(
+            compiled.errors.is_empty(),
+            "Expected no errors, got: {:?}",
+            compiled.errors
+        );
+
+        assert_eq!(
+            compiled.output,
+            indoc! {
+                "
+                j main
+                main:
+                l r15 d0 Setting
+                move r8 r15
+                l r15 d1 Setting
+                move r9 r15
+                "
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn test_tuple_literal_assignment() -> anyhow::Result<()> {
         let compiled = compile!(
             check

--- a/rust_compiler/libs/compiler/src/v1.rs
+++ b/rust_compiler/libs/compiler/src/v1.rs
@@ -192,16 +192,32 @@ pub struct Compiler<'a> {
     pub metadata: crate::CompilationMetadata<'a>,
 }
 
+/// Chains multiple operand compilations together, injecting a "prevent_return_operand_collision"
+/// inbetween expressions.
+///
+/// # Example
+/// ```
+/// let ((expr, cleanup)) = compile_operands!(self, (*operand), scope);
+/// let ((expr1, cleanup1), (expr2, cleanup2), (expr3, cleanup3)) = compile_operands!(self, (*operand1, *operand2, *operand3), scope);
+/// ```
 macro_rules! compile_operands {
-    ($self:expr, $scope:expr, $tail:expr) => {
-        ( $self.compile_operand($tail, $scope)? )
+    (@increment $self:expr, $scope:expr, [$($acc:tt)*];) => {
+        ($($acc)*)
     };
-    ($self:expr, $scope:expr, $($preceeding:expr),*; $tail:expr) => {
-        ($( {
-            let (opr, cleanup) = $self.compile_operand($preceeding, $scope)?;
-            $self.prevent_return_operand_collision(opr, cleanup, $scope)?
-        },)* $self.compile_operand($tail, $scope)?)
+    (@increment $self:expr, $scope:expr, [$($acc:tt)*]; $expr:expr) => {
+        compile_operands!{
+            @increment $self, $scope, [$($acc)* $self.compile_operand($expr, $scope)?,];
+        }
     };
+    (@increment $self:expr, $scope:expr, [$($acc:tt)*]; $expr:expr, $($tail:tt)*) => {
+        compile_operands!{
+            @increment $self, $scope, [$($acc)* {
+                let (opr, cleanup) = $self.compile_operand($expr, $scope)?;
+                $self.prevent_return_operand_collision(opr, cleanup, $scope)?
+            },]; $($tail)*
+        }
+    };
+    ($self:expr, ($($toks:tt)+), $scope:expr) => { compile_operands! {@increment $self, $scope, []; $($toks)*} };
 }
 
 impl<'a> Compiler<'a> {
@@ -1232,7 +1248,7 @@ impl<'a> Compiler<'a> {
                 }
 
                 let ((addr, addr_cleanup), (val, val_cleanup)) =
-                    compile_operands!(self, scope, *index; *expression);
+                    compile_operands!(self, (*index, *expression), scope);
 
                 self.write_instruction(Instruction::Put(device, addr, val), Some(assignee.span))?;
 
@@ -2143,7 +2159,7 @@ impl<'a> Compiler<'a> {
         };
 
         let ((cond, cond_clean), (true_val, true_clean), (false_val, false_clean)) =
-            compile_operands!(self, scope, *condition, *true_value; *false_value);
+            compile_operands!(self, (*condition, *true_value, *false_value), scope);
 
         let result_name = self.next_temp_name();
         let result_loc = scope.add_variable(result_name.clone(), LocationRequest::Temp, None)?;
@@ -2573,7 +2589,7 @@ impl<'a> Compiler<'a> {
         let span = Self::merge_spans(left_expr.span, right_expr.span);
 
         // Compile LHS
-        let (lhs_tup, rhs_tup) = compile_operands!(self, scope, *left_expr; *right_expr);
+        let (lhs_tup, rhs_tup) = compile_operands!(self, (*left_expr, *right_expr), scope);
 
         // Allocate result register
         let result_name = self.next_temp_name();
@@ -2666,7 +2682,7 @@ impl<'a> Compiler<'a> {
                 let span = Self::merge_spans(left_expr.span, right_expr.span);
 
                 let ((lhs, lhs_cleanup), (rhs, rhs_cleanup)) =
-                    compile_operands!(self, scope, *left_expr; *right_expr);
+                    compile_operands!(self, (*left_expr, *right_expr), scope);
 
                 // Allocate result register
                 let result_name = self.next_temp_name();
@@ -3369,7 +3385,7 @@ impl<'a> Compiler<'a> {
             }
             System::LoadBatchSlot(device_hash, slot_index, logic_slot_type, batch_mode) => {
                 let ((device_hash, device_hash_cleanup), (slot_index, slot_cleanup)) =
-                    compile_operands!(self, scope, *device_hash; *slot_index);
+                    compile_operands!(self, (*device_hash, *slot_index), scope);
 
                 let logic_slot_type_expr = match logic_slot_type.node {
                     LiteralOrVariable::Literal(lit) => Expression::Literal(Spanned {
@@ -3431,7 +3447,7 @@ impl<'a> Compiler<'a> {
                     (device_hash, device_hash_cleanup),
                     (name_hash, name_hash_cleanup),
                     (slot_index, slot_cleanup),
-                ) = compile_operands!(self, scope, *device_hash, *name_hash; *slot_index);
+                ) = compile_operands!(self, (*device_hash, *name_hash, *slot_index), scope);
 
                 let logic_slot_type_expr = match logic_slot_type.node {
                     LiteralOrVariable::Literal(lit) => Expression::Literal(Spanned {
@@ -3525,7 +3541,7 @@ impl<'a> Compiler<'a> {
                 let (dev_name, name_cleanup) =
                     self.compile_literal_or_variable(dev_name.node, scope)?;
                 let ((slot_index, index_cleanup), (var, var_cleanup)) =
-                    compile_operands!(self, scope, *slot_index; *var);
+                    compile_operands!(self, (*slot_index, *var), scope);
 
                 // Convert LiteralOrVariable to Expression and validate it's a constant string
                 let logic_type_expr = match logic_type.node {
@@ -3720,7 +3736,7 @@ impl<'a> Compiler<'a> {
             }
             Math::Atan2(expr1, expr2) => {
                 let ((var1, var1_cleanup), (var2, var2_cleanup)) =
-                    compile_operands!(self, scope, *expr1; *expr2);
+                    compile_operands!(self, (*expr1, *expr2), scope);
 
                 self.write_instruction(
                     Instruction::Atan2(
@@ -3808,7 +3824,7 @@ impl<'a> Compiler<'a> {
             }
             Math::Max(expr1, expr2) => {
                 let ((var1, clean1), (var2, clean2)) =
-                    compile_operands!(self, scope, *expr1; *expr2);
+                    compile_operands!(self, (*expr1, *expr2), scope);
 
                 self.write_instruction(
                     Instruction::Max(
@@ -3827,7 +3843,7 @@ impl<'a> Compiler<'a> {
             }
             Math::Min(expr1, expr2) => {
                 let ((var1, clean1), (var2, clean2)) =
-                    compile_operands!(self, scope, *expr1; *expr2);
+                    compile_operands!(self, (*expr1, *expr2), scope);
 
                 self.write_instruction(
                     Instruction::Min(

--- a/rust_compiler/libs/compiler/src/v1.rs
+++ b/rust_compiler/libs/compiler/src/v1.rs
@@ -192,7 +192,7 @@ pub struct Compiler<'a> {
     pub metadata: crate::CompilationMetadata<'a>,
 }
 
-/// Chains multiple operand compilations together, injecting a "prevent_return_operand_collision"
+/// Chains multiple operand compilations together, injecting a "prevent_return_register_clobbering"
 /// inbetween expressions.
 ///
 /// # Example
@@ -213,7 +213,7 @@ macro_rules! compile_operands {
         compile_operands!{
             @increment $self, $scope, [$($acc)* {
                 let (opr, cleanup) = $self.compile_operand($expr, $scope)?;
-                $self.prevent_return_operand_collision(opr, cleanup, $scope)?
+                $self.prevent_return_register_clobbering(opr, cleanup, $scope)?
             },]; $($tail)*
         }
     };
@@ -2289,9 +2289,9 @@ impl<'a> Compiler<'a> {
         }
     }
 
-    // Compiles multiple expressions catching cases where function/syscall returns yield
-    // overwritting stores to the return register (r15).
-    fn prevent_return_operand_collision(
+    /// Prevents clobbering of the return-register in multi-operand expressions
+    /// by moving the return register of a parsed operand into a new temporary register.
+    fn prevent_return_register_clobbering(
         &mut self,
         operand: Operand<'a>,
         cleanup: Option<Cow<'a, str>>,

--- a/rust_compiler/libs/compiler/src/v1.rs
+++ b/rust_compiler/libs/compiler/src/v1.rs
@@ -3328,9 +3328,8 @@ impl<'a> Compiler<'a> {
                 }))
             }
             System::LoadBatchNamed(device_hash, name_hash, logic_type, batch_mode) => {
-                let (device_hash, device_hash_cleanup) =
-                    self.compile_operand(*device_hash, scope)?;
-                let (name_hash, name_hash_cleanup) = self.compile_operand(*name_hash, scope)?;
+                let ((device_hash, device_hash_cleanup), (name_hash, name_hash_cleanup)) =
+                    compile_operands!(self, (*device_hash, *name_hash), scope);
 
                 // Convert LiteralOrVariable to Expression and validate it's a constant string
                 let logic_type_expr = match logic_type.node {

--- a/rust_compiler/libs/compiler/src/v1.rs
+++ b/rust_compiler/libs/compiler/src/v1.rs
@@ -192,6 +192,12 @@ pub struct Compiler<'a> {
     pub metadata: crate::CompilationMetadata<'a>,
 }
 
+macro_rules! compile_operands {
+    ($self:expr, $($preceeding:expr),*; $tail:expr, $scope:expr) => {
+        ($($self.compile_preceeding_operand($preceeding, $scope)?,)* $self.compile_operand($tail, $scope)?)
+    };
+}
+
 impl<'a> Compiler<'a> {
     pub fn new(parser: ASTParser<'a>, config: Option<CompilerConfig>) -> Self {
         Self {
@@ -1219,8 +1225,9 @@ impl<'a> Compiler<'a> {
                     }
                 }
 
-                let (addr, addr_cleanup) = self.compile_operand(*index, scope)?;
-                let (val, val_cleanup) = self.compile_operand(*expression, scope)?;
+                // TODO (check for the bug!)
+                let ((addr, addr_cleanup), (val, val_cleanup)) =
+                    compile_operands!(self, *index; *expression, scope);
 
                 self.write_instruction(Instruction::Put(device, addr, val), Some(assignee.span))?;
 
@@ -1583,6 +1590,7 @@ impl<'a> Compiler<'a> {
                 }
 
                 // Compile each element and assign to corresponding variable
+                // TODO (This needs to be checked and tested for the bug!)
                 for (name_spanned, element) in names.into_iter().zip(tuple_elements.into_iter()) {
                     // Skip underscores
                     if name_spanned.node.as_ref() == "_" {
@@ -2130,9 +2138,8 @@ impl<'a> Compiler<'a> {
             end_col: false_value.span.end_col,
         };
 
-        let (cond, cond_clean) = self.compile_operand(*condition, scope)?;
-        let (true_val, true_clean) = self.compile_operand(*true_value, scope)?;
-        let (false_val, false_clean) = self.compile_operand(*false_value, scope)?;
+        let ((cond, cond_clean), (true_val, true_clean), (false_val, false_clean)) =
+            compile_operands!(self, *condition, *true_value; *false_value, scope);
 
         let result_name = self.next_temp_name();
         let result_loc = scope.add_variable(result_name.clone(), LocationRequest::Temp, None)?;
@@ -2259,6 +2266,32 @@ impl<'a> Compiler<'a> {
                 Ok((Operand::Register(temp_reg), Some(temp_name)))
             }
             VariableLocation::Device(d) => Ok((Operand::Device(d), None)),
+        }
+    }
+
+    // Compiles multiple expressions catching cases where function/syscall returns yield
+    // overwritting stores to the return register (r15).
+    fn compile_preceeding_operand(
+        &mut self,
+        expr: Spanned<Expression<'a>>,
+        scope: &mut VariableScope<'a, '_>,
+    ) -> Result<(Operand<'a>, Option<Cow<'a, str>>), Error<'a>> {
+        // Compile first
+        let (opr, opr_cleanup) = self.compile_operand(expr, scope)?;
+
+        // If opr result landed in RETURN_REGISTER, spill it to a fresh temp before
+        // compiling the next operand, which may also emit a syscall and overwrite that register.
+        if matches!(opr, Operand::Register(r) if r == VariableScope::RETURN_REGISTER) {
+            let spill_name = self.next_temp_name();
+            let spill_loc = scope.add_variable(spill_name.clone(), LocationRequest::Temp, None)?;
+            let spill_reg = self.resolve_register(&spill_loc)?;
+            self.write_instruction(Instruction::Move(Operand::Register(spill_reg), opr), None)?;
+            if let Some(name) = opr_cleanup {
+                scope.free_temp(name, None)?;
+            }
+            Ok((Operand::Register(spill_reg), Some(spill_name)))
+        } else {
+            Ok((opr, opr_cleanup))
         }
     }
 
@@ -2536,26 +2569,7 @@ impl<'a> Compiler<'a> {
         let span = Self::merge_spans(left_expr.span, right_expr.span);
 
         // Compile LHS
-        let (lhs, lhs_cleanup) = self.compile_operand(*left_expr, scope)?;
-
-        // If LHS result landed in RETURN_REGISTER, spill it to a fresh temp before
-        // compiling RHS, which may also emit a syscall and overwrite that register.
-        let (lhs, lhs_cleanup) = if matches!(lhs, Operand::Register(r) if r == VariableScope::RETURN_REGISTER)
-        {
-            let spill_name = self.next_temp_name();
-            let spill_loc = scope.add_variable(spill_name.clone(), LocationRequest::Temp, None)?;
-            let spill_reg = self.resolve_register(&spill_loc)?;
-            self.write_instruction(Instruction::Move(Operand::Register(spill_reg), lhs), None)?;
-            if let Some(name) = lhs_cleanup {
-                scope.free_temp(name, None)?;
-            }
-            (Operand::Register(spill_reg), Some(spill_name))
-        } else {
-            (lhs, lhs_cleanup)
-        };
-
-        // Compile RHS
-        let (rhs, rhs_cleanup) = self.compile_operand(*right_expr, scope)?;
+        let (lhs_tup, rhs_tup) = compile_operands!(self, *left_expr; *right_expr, scope);
 
         // Allocate result register
         let result_name = self.next_temp_name();
@@ -2564,12 +2578,12 @@ impl<'a> Compiler<'a> {
 
         // Emit instruction: op result lhs rhs
         self.write_instruction(
-            op_instr(Operand::Register(result_reg), lhs, rhs),
+            op_instr(Operand::Register(result_reg), lhs_tup.0, rhs_tup.0),
             Some(span),
         )?;
 
         // Clean up operand temps
-        Self::cleanup_temps(scope, &[lhs_cleanup, rhs_cleanup])?;
+        Self::cleanup_temps(scope, &[lhs_tup.1, rhs_tup.1])?;
 
         Ok(CompileLocation {
             location: result_loc,
@@ -2647,31 +2661,9 @@ impl<'a> Compiler<'a> {
 
                 let span = Self::merge_spans(left_expr.span, right_expr.span);
 
-                // Compile LHS
-                let (lhs, lhs_cleanup) = self.compile_operand(*left_expr, scope)?;
-
-                // If LHS result landed in RETURN_REGISTER, spill it to a fresh temp before
-                // compiling RHS, which may also emit a syscall and overwrite that register.
-                let (lhs, lhs_cleanup) = if matches!(lhs, Operand::Register(r) if r == VariableScope::RETURN_REGISTER)
-                {
-                    let spill_name = self.next_temp_name();
-                    let spill_loc =
-                        scope.add_variable(spill_name.clone(), LocationRequest::Temp, None)?;
-                    let spill_reg = self.resolve_register(&spill_loc)?;
-                    self.write_instruction(
-                        Instruction::Move(Operand::Register(spill_reg), lhs),
-                        None,
-                    )?;
-                    if let Some(name) = lhs_cleanup {
-                        scope.free_temp(name, None)?;
-                    }
-                    (Operand::Register(spill_reg), Some(spill_name))
-                } else {
-                    (lhs, lhs_cleanup)
-                };
-
-                // Compile RHS
-                let (rhs, rhs_cleanup) = self.compile_operand(*right_expr, scope)?;
+                // TODO (check for the bug!)
+                let ((lhs, lhs_cleanup), (rhs, rhs_cleanup)) =
+                    compile_operands!(self, *left_expr; *right_expr, scope);
 
                 // Allocate result register
                 let result_name = self.next_temp_name();
@@ -2923,6 +2915,7 @@ impl<'a> Compiler<'a> {
                     let tuple_size = tuple_elements.len();
 
                     // Push each tuple element onto the stack using compile_operand
+                    // TODO (CHECK FOR BUG!)
                     for element in tuple_elements.into_iter() {
                         let (push_operand, cleanup) = self.compile_operand(element, scope)?;
 
@@ -3373,6 +3366,7 @@ impl<'a> Compiler<'a> {
                 }))
             }
             System::LoadBatchSlot(device_hash, slot_index, logic_slot_type, batch_mode) => {
+                // TODO (CHECK FOR BUG)!
                 let (device_hash, device_hash_cleanup) =
                     self.compile_operand(*device_hash, scope)?;
                 let (slot_index, slot_cleanup) = self.compile_operand(*slot_index, scope)?;
@@ -3433,6 +3427,7 @@ impl<'a> Compiler<'a> {
                 logic_slot_type,
                 batch_mode,
             ) => {
+                // TODO (CHECK FOR BUG)!
                 let (device_hash, device_hash_cleanup) =
                     self.compile_operand(*device_hash, scope)?;
                 let (name_hash, name_hash_cleanup) = self.compile_operand(*name_hash, scope)?;
@@ -3527,6 +3522,7 @@ impl<'a> Compiler<'a> {
                 }))
             }
             System::SetSlot(dev_name, slot_index, logic_type, var) => {
+                // TODO (CHECK FOR BUG)!
                 let (dev_name, name_cleanup) =
                     self.compile_literal_or_variable(dev_name.node, scope)?;
                 let (slot_index, index_cleanup) = self.compile_operand(*slot_index, scope)?;
@@ -3725,6 +3721,7 @@ impl<'a> Compiler<'a> {
                 }))
             }
             Math::Atan2(expr1, expr2) => {
+                // TODO (CHECK FOR BUG)!
                 let (var1, var1_cleanup) = self.compile_operand(*expr1, scope)?;
                 let (var2, var2_cleanup) = self.compile_operand(*expr2, scope)?;
 
@@ -3813,8 +3810,8 @@ impl<'a> Compiler<'a> {
                 }))
             }
             Math::Max(expr1, expr2) => {
-                let (var1, clean1) = self.compile_operand(*expr1, scope)?;
-                let (var2, clean2) = self.compile_operand(*expr2, scope)?;
+                let ((var1, clean1), (var2, clean2)) =
+                    compile_operands!(self, *expr1; *expr2, scope);
 
                 self.write_instruction(
                     Instruction::Max(
@@ -3832,6 +3829,7 @@ impl<'a> Compiler<'a> {
                 }))
             }
             Math::Min(expr1, expr2) => {
+                // TODO (CHECK FOR BUG)!
                 let (var1, clean1) = self.compile_operand(*expr1, scope)?;
                 let (var2, clean2) = self.compile_operand(*expr2, scope)?;
 

--- a/rust_compiler/libs/compiler/src/v1.rs
+++ b/rust_compiler/libs/compiler/src/v1.rs
@@ -193,8 +193,14 @@ pub struct Compiler<'a> {
 }
 
 macro_rules! compile_operands {
-    ($self:expr, $($preceeding:expr),*; $tail:expr, $scope:expr) => {
-        ($($self.compile_preceeding_operand($preceeding, $scope)?,)* $self.compile_operand($tail, $scope)?)
+    ($self:expr, $scope:expr, $tail:expr) => {
+        ( $self.compile_operand($tail, $scope)? )
+    };
+    ($self:expr, $scope:expr, $($preceeding:expr),*; $tail:expr) => {
+        ($( {
+            let (opr, cleanup) = $self.compile_operand($preceeding, $scope)?;
+            $self.prevent_return_operand_collision(opr, cleanup, $scope)?
+        },)* $self.compile_operand($tail, $scope)?)
     };
 }
 
@@ -1225,9 +1231,8 @@ impl<'a> Compiler<'a> {
                     }
                 }
 
-                // TODO (check for the bug!)
                 let ((addr, addr_cleanup), (val, val_cleanup)) =
-                    compile_operands!(self, *index; *expression, scope);
+                    compile_operands!(self, scope, *index; *expression);
 
                 self.write_instruction(Instruction::Put(device, addr, val), Some(assignee.span))?;
 
@@ -2139,7 +2144,7 @@ impl<'a> Compiler<'a> {
         };
 
         let ((cond, cond_clean), (true_val, true_clean), (false_val, false_clean)) =
-            compile_operands!(self, *condition, *true_value; *false_value, scope);
+            compile_operands!(self, scope, *condition, *true_value; *false_value);
 
         let result_name = self.next_temp_name();
         let result_loc = scope.add_variable(result_name.clone(), LocationRequest::Temp, None)?;
@@ -2271,28 +2276,28 @@ impl<'a> Compiler<'a> {
 
     // Compiles multiple expressions catching cases where function/syscall returns yield
     // overwritting stores to the return register (r15).
-    fn compile_preceeding_operand(
+    fn prevent_return_operand_collision(
         &mut self,
-        expr: Spanned<Expression<'a>>,
+        operand: Operand<'a>,
+        cleanup: Option<Cow<'a, str>>,
         scope: &mut VariableScope<'a, '_>,
     ) -> Result<(Operand<'a>, Option<Cow<'a, str>>), Error<'a>> {
-        // Compile first
-        let (opr, opr_cleanup) = self.compile_operand(expr, scope)?;
-
         // If opr result landed in RETURN_REGISTER, spill it to a fresh temp before
         // compiling the next operand, which may also emit a syscall and overwrite that register.
-        if matches!(opr, Operand::Register(r) if r == VariableScope::RETURN_REGISTER) {
-            let spill_name = self.next_temp_name();
-            let spill_loc = scope.add_variable(spill_name.clone(), LocationRequest::Temp, None)?;
-            let spill_reg = self.resolve_register(&spill_loc)?;
-            self.write_instruction(Instruction::Move(Operand::Register(spill_reg), opr), None)?;
-            if let Some(name) = opr_cleanup {
-                scope.free_temp(name, None)?;
-            }
-            Ok((Operand::Register(spill_reg), Some(spill_name)))
-        } else {
-            Ok((opr, opr_cleanup))
+        if !matches!(operand, Operand::Register(r) if r == VariableScope::RETURN_REGISTER) {
+            return Ok((operand, cleanup));
         }
+        let spill_name = self.next_temp_name();
+        let spill_loc = scope.add_variable(spill_name.clone(), LocationRequest::Temp, None)?;
+        let spill_reg = self.resolve_register(&spill_loc)?;
+        self.write_instruction(
+            Instruction::Move(Operand::Register(spill_reg), operand),
+            None,
+        )?;
+        if let Some(name) = cleanup {
+            scope.free_temp(name, None)?;
+        }
+        Ok((Operand::Register(spill_reg), Some(spill_name)))
     }
 
     fn compile_literal_or_variable(
@@ -2569,7 +2574,7 @@ impl<'a> Compiler<'a> {
         let span = Self::merge_spans(left_expr.span, right_expr.span);
 
         // Compile LHS
-        let (lhs_tup, rhs_tup) = compile_operands!(self, *left_expr; *right_expr, scope);
+        let (lhs_tup, rhs_tup) = compile_operands!(self, scope, *left_expr; *right_expr);
 
         // Allocate result register
         let result_name = self.next_temp_name();
@@ -2661,9 +2666,8 @@ impl<'a> Compiler<'a> {
 
                 let span = Self::merge_spans(left_expr.span, right_expr.span);
 
-                // TODO (check for the bug!)
                 let ((lhs, lhs_cleanup), (rhs, rhs_cleanup)) =
-                    compile_operands!(self, *left_expr; *right_expr, scope);
+                    compile_operands!(self, scope, *left_expr; *right_expr);
 
                 // Allocate result register
                 let result_name = self.next_temp_name();
@@ -3366,10 +3370,8 @@ impl<'a> Compiler<'a> {
                 }))
             }
             System::LoadBatchSlot(device_hash, slot_index, logic_slot_type, batch_mode) => {
-                // TODO (CHECK FOR BUG)!
-                let (device_hash, device_hash_cleanup) =
-                    self.compile_operand(*device_hash, scope)?;
-                let (slot_index, slot_cleanup) = self.compile_operand(*slot_index, scope)?;
+                let ((device_hash, device_hash_cleanup), (slot_index, slot_cleanup)) =
+                    compile_operands!(self, scope, *device_hash; *slot_index);
 
                 let logic_slot_type_expr = match logic_slot_type.node {
                     LiteralOrVariable::Literal(lit) => Expression::Literal(Spanned {
@@ -3427,11 +3429,11 @@ impl<'a> Compiler<'a> {
                 logic_slot_type,
                 batch_mode,
             ) => {
-                // TODO (CHECK FOR BUG)!
-                let (device_hash, device_hash_cleanup) =
-                    self.compile_operand(*device_hash, scope)?;
-                let (name_hash, name_hash_cleanup) = self.compile_operand(*name_hash, scope)?;
-                let (slot_index, slot_cleanup) = self.compile_operand(*slot_index, scope)?;
+                let (
+                    (device_hash, device_hash_cleanup),
+                    (name_hash, name_hash_cleanup),
+                    (slot_index, slot_cleanup),
+                ) = compile_operands!(self, scope, *device_hash, *name_hash; *slot_index);
 
                 let logic_slot_type_expr = match logic_slot_type.node {
                     LiteralOrVariable::Literal(lit) => Expression::Literal(Spanned {
@@ -3522,10 +3524,10 @@ impl<'a> Compiler<'a> {
                 }))
             }
             System::SetSlot(dev_name, slot_index, logic_type, var) => {
-                // TODO (CHECK FOR BUG)!
                 let (dev_name, name_cleanup) =
                     self.compile_literal_or_variable(dev_name.node, scope)?;
-                let (slot_index, index_cleanup) = self.compile_operand(*slot_index, scope)?;
+                let ((slot_index, index_cleanup), (var, var_cleanup)) =
+                    compile_operands!(self, scope, *slot_index; *var);
 
                 // Convert LiteralOrVariable to Expression and validate it's a constant string
                 let logic_type_expr = match logic_type.node {
@@ -3543,8 +3545,6 @@ impl<'a> Compiler<'a> {
                     scope,
                     span,
                 )?;
-
-                let (var, var_cleanup) = self.compile_operand(*var, scope)?;
 
                 self.write_instruction(
                     Instruction::StoreSlot(
@@ -3721,9 +3721,8 @@ impl<'a> Compiler<'a> {
                 }))
             }
             Math::Atan2(expr1, expr2) => {
-                // TODO (CHECK FOR BUG)!
-                let (var1, var1_cleanup) = self.compile_operand(*expr1, scope)?;
-                let (var2, var2_cleanup) = self.compile_operand(*expr2, scope)?;
+                let ((var1, var1_cleanup), (var2, var2_cleanup)) =
+                    compile_operands!(self, scope, *expr1; *expr2);
 
                 self.write_instruction(
                     Instruction::Atan2(
@@ -3811,7 +3810,7 @@ impl<'a> Compiler<'a> {
             }
             Math::Max(expr1, expr2) => {
                 let ((var1, clean1), (var2, clean2)) =
-                    compile_operands!(self, *expr1; *expr2, scope);
+                    compile_operands!(self, scope, *expr1; *expr2);
 
                 self.write_instruction(
                     Instruction::Max(
@@ -3829,9 +3828,8 @@ impl<'a> Compiler<'a> {
                 }))
             }
             Math::Min(expr1, expr2) => {
-                // TODO (CHECK FOR BUG)!
-                let (var1, clean1) = self.compile_operand(*expr1, scope)?;
-                let (var2, clean2) = self.compile_operand(*expr2, scope)?;
+                let ((var1, clean1), (var2, clean2)) =
+                    compile_operands!(self, scope, *expr1; *expr2);
 
                 self.write_instruction(
                     Instruction::Min(

--- a/rust_compiler/libs/compiler/src/v1.rs
+++ b/rust_compiler/libs/compiler/src/v1.rs
@@ -1595,7 +1595,6 @@ impl<'a> Compiler<'a> {
                 }
 
                 // Compile each element and assign to corresponding variable
-                // TODO (This needs to be checked and tested for the bug!)
                 for (name_spanned, element) in names.into_iter().zip(tuple_elements.into_iter()) {
                     // Skip underscores
                     if name_spanned.node.as_ref() == "_" {
@@ -2919,7 +2918,6 @@ impl<'a> Compiler<'a> {
                     let tuple_size = tuple_elements.len();
 
                     // Push each tuple element onto the stack using compile_operand
-                    // TODO (CHECK FOR BUG!)
                     for element in tuple_elements.into_iter() {
                         let (push_operand, cleanup) = self.compile_operand(element, scope)?;
 


### PR DESCRIPTION
The compiler's `compile_operand` has the hazard of clobbering (overwriting) the return register of the passed expression if a previous `compile_operand` stored a value in the return register (r15).  The fold expressions in the compiler guard against this by injecting a move of the return register into a temporary register.  However, other multi-operand expressions (i.e. `loadBatched`, `max`, etc.) do not have this protection and thus exhibit clobbering.

This solution adds the prevention logic in the fold expressions into the other multi-operand expressions.  To aid in prevalence of this pattern, the `compile_commands!` macro was created to ergonomically declare one or more operands to compile, interleaving the prevention logic between them.  This was chosen as opposed to modifying the `compile_operand` function as (a) it may be incorrect or violate an assumption in the code; and (b) it would modify the expected instructions for a significant number of tests.

### Example
Source:
```
let delta = max(
  loadBatched(hash("StructureBattery"), "PowerPotential", "Maximum"),
  loadBatched(hash("StructureBatteryLarge"), "PowerPotential", "Maximum"),
);
```

Version 0.7.2:
```
j main
main:
lb r15 -400115994 PowerPotential Maximum
lb r15 -1388288459 PowerPotential Maximum # Previous store was clobbered!
max r15 r15 r15
move r8 r15
```

PR:
```
j main
main:
lb r15 -400115994 PowerPotential Maximum
move r1 r15 # Clobber-prevention
lb r15 -1388288459 PowerPotential Maximum
max r15 r1 r15
move r8 r15
```

### Changes
- Added the `prevent_return_register_clobbering` function to the compiler to store the existing behavior in fold expressions preventing return-register clobbering.
- Added the `compile_commands!` macro for ergonomically parse multiple operands and interleaving the `prevent_return_register_clobbering` in between `compile_operand`.
- Changed all blocks compiling multiple operands to use the `compile_commands!` macro.
- Added tests for expressions identified to have this problem (see the "from_syscall" tests).

### Acknowledgements
This PR was created while investigating #56 .  I have not guaranteed that this solve that issue but I suspect it is the source of it.

Tuples were a potential hazard but their storage logic prevents this hazard from appearing.  Nevertheless, tests for this hazard on tuples was added.